### PR TITLE
Fix up most usages of `unwrap`

### DIFF
--- a/src/commands/pokemon_command.rs
+++ b/src/commands/pokemon_command.rs
@@ -94,6 +94,7 @@ impl PokemonCommand<'_> {
                 let client_ref = &self.client;
 
                 async move {
+                    // TODO: Gracefully filter out failed requests for an ability
                     let ability = client_ref.fetch_ability(&a.ability.name).await.unwrap();
 
                     FormatAbility::new(ability, Rc::clone(pokemon_ref))

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -3,12 +3,9 @@ use crate::type_colours::{self};
 use std::rc::Rc;
 
 use colored::*;
-use rustemon::{
-    model::{
-        moves::{Move, MoveLearnMethod},
-        pokemon::{Ability, Pokemon, PokemonMoveVersion},
-    },
-    moves::move_learn_method,
+use rustemon::model::{
+    moves::{Move, MoveLearnMethod},
+    pokemon::{Ability, Pokemon, PokemonMoveVersion},
 };
 
 pub trait FormatModel {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,9 @@ fn get_optional_strings(command: &str, sub_matches: &ArgMatches) -> Option<Vec<S
 }
 
 fn get_required_string(command: &str, sub_matches: &ArgMatches) -> String {
-    get_optional_string(command, sub_matches).unwrap()
+    get_optional_string(command, sub_matches).unwrap_or_else(|| {
+        panic!("{}", format!("{command} is required!"));
+    })
 }
 
 fn get_optional_bool(command: &str, sub_matches: &ArgMatches) -> bool {

--- a/src/name_matcher/matcher.rs
+++ b/src/name_matcher/matcher.rs
@@ -64,14 +64,14 @@ pub fn try_suggest_name(name: &str, matcher_type: MatcherType) -> String {
 }
 
 fn matcher_and_keyword(matcher_type: MatcherType) -> (NameMatcher, String) {
-    let names_and_keyword = match matcher_type {
+    let (names, keyword) = match matcher_type {
         MatcherType::Move => (&MOVE_NAMES, "move"),
         MatcherType::Pokemon => (&POKEMON_NAMES, "pokemon"),
         MatcherType::Type => (&TYPE_NAMES, "type"),
     };
 
     (
-        NameMatcher::new(Lazy::force(names_and_keyword.0).to_owned()),
-        String::from(names_and_keyword.1),
+        NameMatcher::new(Lazy::force(names).to_owned()),
+        String::from(keyword),
     )
 }


### PR DESCRIPTION
Some of the new pokemon data isn't complete which is causing crashes in certain areas we use `unwrap` instead of handling the case a value is missing