### PR TITLE
Change pokemon arg for moves command to not be a flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ struct Cli {
 enum Commands {
     #[command(about = "See moves for a pokemon")]
     Moves {
-        #[arg(short, long)]
         #[arg(help = "The name of the pokemon you want to see moves for")]
         pokemon: String,
 


### PR DESCRIPTION
The flag is unnecessary and inconsistent with other commands

```sh
poke_search_cli moves pikachu

# instead of

poke_search_cli moves -p pikachu
# or
poke_search_cli moves --pokemon pikachu
```